### PR TITLE
Allow configuring number of rates to be displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Here's a breakdown of all the available configuration items:
 |-------------|----------|---------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | entity      | N        | N/A           | Name of the sensor that contains the rates you want to render, generated from the `HomeAssistant-OctopusEnergy` integration                          |
 | cols        | Y        | 1             | How many columns to break the rates in to, pick the one that fits best with how wide your card is                                                    |
+| count       | Y        | All           | How many rates to show                                                    |
 | showpast    | Y        | false         | Show the rates that have already happened today. Provides a simpler card when there are two days of dates to show                                    |
 | showday     | Y        | false         | Shows the (short) day of the week next to the time for each rate. Helpful if it's not clear which day is which if you have a lot of rates to display |
 | title       | Y        | "Agile Rates" | The title of the card in the dashboard                                                                                                               |

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -95,6 +95,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         const showpast = config.showpast;
         const showday = config.showday;
         const hour12 = config.hour12;
+		const count = config.count || -1;
 
         var colours = (config.exportrates ? colours_export : colours_import);
 
@@ -115,7 +116,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         rates.forEach(function (key) {
             const date_milli = Date.parse(key.from);
             var date = new Date(date_milli);
-            if(showpast || (date - Date.parse(new Date())>-1800000)) {
+            if((count !== -1 && rates_list_length < count) && (showpast || (date - Date.parse(new Date())>-1800000))) {
                 rates_list_length++;
             }
         });
@@ -127,6 +128,9 @@ class OctopusEnergyRatesCard extends HTMLElement {
         var x = 1;
 
         rates.forEach(function (key) {
+			if (count !== -1 && x > count) {
+				return;
+			}
             const date_milli = Date.parse(key.from);
             var date = new Date(date_milli);
             const lang = navigator.language || navigator.languages[0];


### PR DESCRIPTION
In some dashboards I don't have the space to show all rates, so adding configuration to control the number of rates the card will show.