### PR TITLE
Fix rates for Octopus integration v8.0.0

### DIFF
--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -99,7 +99,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         var colours = (config.exportrates ? colours_export : colours_import);
 
         // Grab the rates which are stored as an attribute of the sensor
-        var rates = attributes.rates
+        var rates = attributes.all_rates
         // Check to see if the 'rates' attribute exists on the chosen entity. If not, either the wrong entity
         // was chosen or there's something wrong with the integration.
         // The rates attribute also appears to be missing after a restart for a while - please see:
@@ -113,7 +113,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         // TODO: there should be one clear data process loop and one rendering loop? Or a function?
         var rates_list_length = 0;
         rates.forEach(function (key) {
-            const date_milli = Date.parse(key.from);
+            const date_milli = Date.parse(key.valid_from);
             var date = new Date(date_milli);
             if(showpast || (date - Date.parse(new Date())>-1800000)) {
                 rates_list_length++;
@@ -127,7 +127,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         var x = 1;
 
         rates.forEach(function (key) {
-            const date_milli = Date.parse(key.from);
+            const date_milli = Date.parse(key.valid_from);
             var date = new Date(date_milli);
             const lang = navigator.language || navigator.languages[0];
             var options = {hourCycle: 'h23', hour12: hour12, hour: '2-digit', minute:'2-digit'};
@@ -137,13 +137,13 @@ class OctopusEnergyRatesCard extends HTMLElement {
             var date_locale = (showday ? date.toLocaleDateString(lang, { weekday: 'short' }) + ' ' : '');
 
             var colour = colours[0];
-            if(key.rate > config.highlimit) colour = colours[1];
-            else if(key.rate > config.mediumlimit) colour = colours[2];
-            else if(key.rate <= 0 ) colour = colours[3];
+            if(key.value_inc_vat > config.highlimit) colour = colours[1];
+            else if(key.value_inc_vat > config.mediumlimit) colour = colours[2];
+            else if(key.value_inc_vat <= 0 ) colour = colours[3];
 
             if(showpast || (date - Date.parse(new Date())>-1800000)) {
                 table = table.concat("<tr class='rate_row'><td class='time time_"+colour+"'>" + date_locale + time_locale + 
-                        "</td><td class='rate "+colour+"'>" + key.rate.toFixed(roundUnits) + unitstr + "</td></tr>");
+                        "</td><td class='rate "+colour+"'>" + key.value_inc_vat.toFixed(roundUnits) + unitstr + "</td></tr>");
                 if (x % rows_per_col == 0) {
                     tables = tables.concat(table);
                     table = "";


### PR DESCRIPTION
With the release of v8.0.0 of the Octopus integration [a breaking change was made](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy/pull/323) to the rates. We now need to read the `all_rates` attribute, use the `valid_from` attribute on each rate instead of `from`, and the `value_inc_vat` attribute instead of `rate`.