### PR TITLE
Predbat integration of rate card to show battery charging/discharging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lovelace custom card for Octopus Energy Rate display
+# Lovelace custom card for Octopus Energy Rate display (Predbat version, forked)
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
 
@@ -20,7 +20,7 @@ Simply click this button to go directly to the details page:
     
 In the Home Assistant UI:
 * use HACS -> Frontend -> Top Right Menu -> Custom repositories
-* Enter a repo of `lozzd/octopus-energy-rates-card` and category of "Lovelace", and click the Add button
+* Enter a repo of `springfall2008/octopus-energy-rates-card` and category of "Lovelace", and click the Add button
 * Click "Explore & Download Repositories" and start searching for "octo" and you should see the entry. 
 * Click "Download" in the bottom right
 

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -141,9 +141,14 @@ class OctopusEnergyRatesCard extends HTMLElement {
             else if(key.value_inc_vat > config.mediumlimit) colour = colours[2];
             else if(key.value_inc_vat <= 0 ) colour = colours[3];
 
+            var state = ""
+            if (key.hasOwnProperty("state")) {
+                state = key.state
+            }
+
             if(showpast || (date - Date.parse(new Date())>-1800000)) {
                 table = table.concat("<tr class='rate_row'><td class='time time_"+colour+"'>" + date_locale + time_locale + 
-                        "</td><td class='rate "+colour+"'>" + key.value_inc_vat.toFixed(roundUnits) + unitstr + "</td></tr>");
+                        "</td><td class='rate "+colour+"'>" + key.value_inc_vat.toFixed(roundUnits) + unitstr + state + "x </td></tr>");
                 if (x % rows_per_col == 0) {
                     tables = tables.concat(table);
                     table = "";

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -32,7 +32,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
             }
             tr.rate_row{
                 text-align:center;
-                width:80px;
+                width:100px;
             }
             td.time {
                 text-align:center;
@@ -50,17 +50,11 @@ class OctopusEnergyRatesCard extends HTMLElement {
             td.time_blue{
                 border-bottom: 1px solid #391CD9;
             }
-            td.time_grey{
-                border-bottom: 1px solid #AAAAAA;
-            }
-            td.time_white{
-                border-bottom: 1px solid #FFFFFF;
-            }
             td.rate {
                 color:white;
                 text-align:center;
                 vertical-align: middle;
-                width:80px;
+                width:100px;
 
                 border-top-right-radius:15px;
                 border-bottom-right-radius:15px;
@@ -80,6 +74,14 @@ class OctopusEnergyRatesCard extends HTMLElement {
             td.blue {
                 border: 2px solid #391CD9;
                 background-color: #391CD9;
+            }
+            td.white {
+                border: 2px solid #FFFFFF;
+                background-color: #FFFFFF;
+            }
+            td.grey {
+                border: 2px solid #AAAAAA;
+                background-color: #AAAAAA;
             }
             `;
             card.appendChild(style);
@@ -165,7 +167,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
 
             if(showpast || (date - Date.parse(new Date())>-1800000)) {
                 table = table.concat("<tr class='rate_row'><td class='time time_"+colour+"'>" + date_locale + time_locale + 
-                        "</td><td class='rate "+colour+"'>" + key.value_inc_vat.toFixed(roundUnits) + unitstr + "</td><td class='time time_"+colour_state+"'>" + state + "</td></tr>");
+                        "</td><td class='rate "+colour+"'>" + key.value_inc_vat.toFixed(roundUnits) + unitstr + "</td><td class='rate "+colour_state+"'>" + state + "</td></tr>");
                 if (x % rows_per_col == 0) {
                     tables = tables.concat(table);
                     table = "";

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -155,13 +155,17 @@ class OctopusEnergyRatesCard extends HTMLElement {
             if (key.hasOwnProperty("state")) {
                 state = key.state
             }
+            if (state == '') {
+                state = '&nbsp;'
+            }
+
             if (state == 'Charge') {
                 colour_state = 'green'
             }
-            if (state == 'Discharge') {
+            else if (state == 'Discharge') {
                 colour_state = 'red'
             }
-            if (state == 'Freeze') {
+            else if (state == 'Freeze') {
                 colour_state = 'grey'
             }
 

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -50,6 +50,12 @@ class OctopusEnergyRatesCard extends HTMLElement {
             td.time_blue{
                 border-bottom: 1px solid #391CD9;
             }
+            td.time_grey{
+                border-bottom: 1px solid #AAAAAA;
+            }
+            td.time_white{
+                border-bottom: 1px solid #FFFFFF;
+            }
             td.rate {
                 color:white;
                 text-align:center;
@@ -83,6 +89,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
 
         const colours_import = [ 'green', 'red', 'orange', 'blue' ];
         const colours_export = [ 'red', 'green', 'orange' ];
+        const colours_state  = [ 'white', 'green', 'red', 'grey']
 
         const entityId = config.entity;
         const state = hass.states[entityId];
@@ -137,6 +144,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
             var date_locale = (showday ? date.toLocaleDateString(lang, { weekday: 'short' }) + ' ' : '');
 
             var colour = colours[0];
+            var colour_state = colours_state[0]
             if(key.value_inc_vat > config.highlimit) colour = colours[1];
             else if(key.value_inc_vat > config.mediumlimit) colour = colours[2];
             else if(key.value_inc_vat <= 0 ) colour = colours[3];
@@ -145,10 +153,19 @@ class OctopusEnergyRatesCard extends HTMLElement {
             if (key.hasOwnProperty("state")) {
                 state = key.state
             }
+            if (state == 'Charge') {
+                colour_state = 'green'
+            }
+            if (state == 'Discharge') {
+                colour_state = 'red'
+            }
+            if (state == 'Freeze') {
+                colour_state = 'grey'
+            }
 
             if(showpast || (date - Date.parse(new Date())>-1800000)) {
                 table = table.concat("<tr class='rate_row'><td class='time time_"+colour+"'>" + date_locale + time_locale + 
-                        "</td><td class='rate "+colour+"'>" + key.value_inc_vat.toFixed(roundUnits) + unitstr + state + "x </td></tr>");
+                        "</td><td class='rate "+colour+"'>" + key.value_inc_vat.toFixed(roundUnits) + unitstr + "</td><td class='time time_"+colour_state+"'>" + state + "</td></tr>");
                 if (x % rows_per_col == 0) {
                     tables = tables.concat(table);
                     table = "";
@@ -243,5 +260,5 @@ window.customCards.push({
   type: 'octopus-energy-rates-card',
   name: 'Octopus Energy Rates Card',
   preview: false,
-  description: 'This card displays the energy rates for Octopus Energy',
+  description: 'This card displays the energy rates for Octopus Energy, with Predbat information if enabled',
 });


### PR DESCRIPTION
This is a little bit of a hack so probably needs some edits to fold back in.

The idea is that Predbat (https://github.com/springfall2008/batpred) creates custom sensors which look like the Octopus information but include a 'state' variable. This state is show in the rate card so that users can see the charging/discharging plan.

Is there any way we can merge this?

![image](https://github.com/lozzd/octopus-energy-rates-card/assets/48591903/be11ef30-81af-48c3-a4bd-e71414637099)
