### PR TITLE
Fixes for v9.0.0 of HomeAssistant-OctopusEnergy released in November 2023.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ The only **required** key is the name of the entity sensor that contains the rat
 
 The easiest way to find that entity name is by opening the Search within Home Assistant: search for `current_day_rate` -> click the chosen result -> choose the Settings tab -> copy `Entity ID`
 
-(The format is `event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_day_rate`)
+(The format is `event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_day_rates`)
 
-If you want to see tomorrow's rate use a second card with event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_next_day_rate.
+If you want to see tomorrow's rate use a second card with event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_next_day_rates.
 
 Here's an example yaml configuration:
 
 ```
-entity: event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_day_rate
+entity: event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_day_rates
 type: custom:octopus-energy-rates-card
 cols: 2
 showday: true

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ You can also install manually by downloading/copying the Javascript file in to `
 Settings -> Dashboards -> Top Right Menu -> Resources
 
 #### Configuration
+This version of the card requires at least v9.0.0 of https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy.
+
+
 Add the card to your dashboard using **Add Card -> Custom: Octopus Energy Rates Card**
 
 You'll need to then configure the yaml yourself - the `type` part is filled out for you. 
@@ -60,11 +63,11 @@ Here's a breakdown of all the available configuration items:
 | showpast    | Y        | false         | Show the rates that have already happened today. Provides a simpler card when there are two days of dates to show                                    |
 | showday     | Y        | false         | Shows the (short) day of the week next to the time for each rate. Helpful if it's not clear which day is which if you have a lot of rates to display |
 | title       | Y        | "Agile Rates" | The title of the card in the dashboard                                                                                                               |
-| mediumlimit | Y        | 20 (pence)    | If the price is above `mediumlimit`, the row is marked yellow                                                                                        |
-| highlimit   | Y        | 30 (pence)    | If the price is above `highlimit`, the row is marked red.                                                                                            |
-| roundUnits  | Y        | 2             | Controls how many decimal places to round the rates to                                                                                               |
+| mediumlimit | Y        | 0.20 (£)    | If the price is above `mediumlimit`, the row is marked yellow                                                                                        |
+| highlimit   | Y        | 0.30 (£)    | If the price is above `highlimit`, the row is marked red.                                                                                            |
+| roundUnits  | Y        | 3             | Controls how many decimal places to round the rates to                                                                                               |
 | showunits   | Y        | N/A          | No longer supported. Never worked. Please set a blank string using `unitstr` (see below)                                                                                        |
-| unitstr   | Y        | "p/kWh"          | The unit to show after the rate in the table. Set to an empty string for none.                                                                                         |
+| unitstr   | Y        | "£/kWh"          | The unit to show after the rate in the table. Set to an empty string for none.                                                                                         |
 | exportrates   | Y        | false          | Reverses the colours for use when showing export rates instead of import                                                                              |
 | hour12   | Y        | true          | Show the times in 12 hour format if `true`, and 24 hour format if `false`                                                                            |
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,16 @@ You'll need to then configure the yaml yourself - the `type` part is filled out 
 
 The only **required** key is the name of the entity sensor that contains the rates
 
-The easiest way to find that entity name is by opening the Search within Home Assistant: search for `current_rate` -> click the chosen result -> choose the Settings tab -> copy `Entity ID`
+The easiest way to find that entity name is by opening the Search within Home Assistant: search for `current_day_rate` -> click the chosen result -> choose the Settings tab -> copy `Entity ID`
 
-(The format is `sensor.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_rate`)
+(The format is `event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_day_rate`)
+
+If you want to see tomorrow's rate use a second card with event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_next_day_rate.
 
 Here's an example yaml configuration:
 
 ```
-entity: sensor.octopus_energy_electricity_<your_id_here>_current_rate
+entity: event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_day_rate
 type: custom:octopus-energy-rates-card
 cols: 2
 showday: true

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -99,7 +99,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         var colours = (config.exportrates ? colours_export : colours_import);
 
         // Grab the rates which are stored as an attribute of the sensor
-        var rates = attributes.all_rates
+        var rates = attributes.rates
         // Check to see if the 'rates' attribute exists on the chosen entity. If not, either the wrong entity
         // was chosen or there's something wrong with the integration.
         // The rates attribute also appears to be missing after a restart for a while - please see:
@@ -113,7 +113,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         // TODO: there should be one clear data process loop and one rendering loop? Or a function?
         var rates_list_length = 0;
         rates.forEach(function (key) {
-            const date_milli = Date.parse(key.valid_from);
+            const date_milli = Date.parse(key.start);
             var date = new Date(date_milli);
             if(showpast || (date - Date.parse(new Date())>-1800000)) {
                 rates_list_length++;
@@ -127,7 +127,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         var x = 1;
 
         rates.forEach(function (key) {
-            const date_milli = Date.parse(key.valid_from);
+            const date_milli = Date.parse(key.start);
             var date = new Date(date_milli);
             const lang = navigator.language || navigator.languages[0];
             var options = {hourCycle: 'h23', hour12: hour12, hour: '2-digit', minute:'2-digit'};
@@ -205,12 +205,12 @@ class OctopusEnergyRatesCard extends HTMLElement {
             // If the price is above mediumlimit, the row is marked yellow.
             // If the price is below mediumlimit, the row is marked green.
             // If the price is below 0, the row is marked blue.
-            mediumlimit: 20,
-            highlimit: 30,
+            mediumlimit: 0.20,
+            highlimit: 0.30,
             // Controls the rounding of the units of the rate
-            roundUnits: 2,
+            roundUnits: 3,
             // The unit string to show if units are shown after each rate
-            unitstr: 'p/kWh',
+            unitstr: '£/kWh',
             // Make the colouring happen in reverse, for export rates
             exportrates: false,
         };


### PR DESCRIPTION
Fixes to support v9.0.0 of HomeAssistant-OctopusEnergy released in November 2023.
Now need to use an events entity of the form event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_current_day_rates.
Since v9.0 now works in £ not pence I have changed default medium and high limits to 0.2 and 0.3 and rounding to 3 decimal places to show 1/10p.
This version of the card only supports one entity, so if tomorrow's rates are required, create a second card with an entity of the form event.octopus_energy_electricity_{{METER_SERIAL_NUMBER}}_{{MPAN_NUMBER}}_next_day_rates.