### PR TITLE
Add a rate emphasis entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,25 +54,26 @@ showpast: false
 
 Here's a breakdown of all the available configuration items:
 
-| Name          | Optional | Default       | Description                                                                                                                                          |
-|---------------|----------|---------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| currentEntity | N        | N/A           | Name of the sensor that contains the current rates you want to render, generated from the `HomeAssistant-OctopusEnergy` integration                  |
-| pastEntity    | Y        | N/A           | Name of the sensor that contains the past rates you want to render, generated from the `HomeAssistant-OctopusEnergy` integration                     |
-| futureEntity  | Y        | N/A           | Name of the sensor that contains the future rates you want to render, generated from the `HomeAssistant-OctopusEnergy` integration                   |
-| cols          | Y        | 1             | How many columns to break the rates in to, pick the one that fits best with how wide your card is                                                    |
-| showpast      | Y        | false         | Show the rates that have already happened today. Provides a simpler card when there are two days of dates to show                                    |
-| showday       | Y        | false         | Shows the (short) day of the week next to the time for each rate. Helpful if it's not clear which day is which if you have a lot of rates to display |
-| title         | Y        | "Agile Rates" | The title of the card in the dashboard                                                                                                               |
-| mediumlimit   | Y        | 20 (pence)    | If the price is above `mediumlimit`, the row is marked yellow                                                                                        |
-| highlimit     | Y        | 30 (pence)    | If the price is above `highlimit`, the row is marked red.                                                                                            |
-| roundUnits    | Y        | 2             | Controls how many decimal places to round the rates to                                                                                               |
-| showunits     | Y        | N/A           | No longer supported. Never worked. Please set a blank string using `unitstr` (see below)                                                             |
-| unitstr       | Y        | "p/kWh"       | The unit to show after the rate in the table. Set to an empty string for none.                                                                       |
-| exportrates   | Y        | false         | Reverses the colours for use when showing export rates instead of import                                                                             |
-| hour12        | Y        | true          | Show the times in 12 hour format if `true`, and 24 hour format if `false`                                                                            |
-| cheapest      | Y        | false         | If true show the cheapest rate in light green / light blue                                                                                           |
-| combinerate   | Y        | false         | If true combine rows where the rate is the same price, useful if you have a daily tracker tarrif for instance                                        |
-| multiplier    | Y        | 100           | multiple rate values for pence (100) or pounds (1)                                                                                                   |
+| Name            | Optional | Default       | Description                                                                                                                                          |
+|-----------------|----------|---------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| currentEntity   | N        | N/A           | Name of the sensor that contains the current rates you want to render, generated from the `HomeAssistant-OctopusEnergy` integration                  |
+| pastEntity      | Y        | N/A           | Name of the sensor that contains the past rates you want to render, generated from the `HomeAssistant-OctopusEnergy` integration                     |
+| futureEntity    | Y        | N/A           | Name of the sensor that contains the future rates you want to render, generated from the `HomeAssistant-OctopusEnergy` integration                   |
+| emphasisEntity  | Y        | 1             | Name of a sensor that can be used to dynamically emphasis rates. Rates under this value will be shown in bold, black text                            | 
+| cols            | Y        | 1             | How many columns to break the rates in to, pick the one that fits best with how wide your card is                                                    |
+| showpast        | Y        | false         | Show the rates that have already happened today. Provides a simpler card when there are two days of dates to show                                    |
+| showday         | Y        | false         | Shows the (short) day of the week next to the time for each rate. Helpful if it's not clear which day is which if you have a lot of rates to display |
+| title           | Y        | "Agile Rates" | The title of the card in the dashboard                                                                                                               |
+| mediumlimit     | Y        | 20 (pence)    | If the price is above `mediumlimit`, the row is marked yellow                                                                                        |
+| highlimit       | Y        | 30 (pence)    | If the price is above `highlimit`, the row is marked red.                                                                                            |
+| roundUnits      | Y        | 2             | Controls how many decimal places to round the rates to                                                                                               |
+| showunits       | Y        | N/A           | No longer supported. Never worked. Please set a blank string using `unitstr` (see below)                                                             |
+| unitstr         | Y        | "p/kWh"       | The unit to show after the rate in the table. Set to an empty string for none.                                                                       |
+| exportrates     | Y        | false         | Reverses the colours for use when showing export rates instead of import                                                                             |
+| hour12          | Y        | true          | Show the times in 12 hour format if `true`, and 24 hour format if `false`                                                                            |
+| cheapest        | Y        | false         | If true show the cheapest rate in light green / light blue                                                                                           |
+| combinerate     | Y        | false         | If true combine rows where the rate is the same price, useful if you have a daily tracker tarrif for instance                                        |
+| multiplier      | Y        | 100           | multiple rate values for pence (100) or pounds (1)                                                                                                   |
 
 
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "octopus-energy-rates-card",
+    "name": "octopus-energy-rates-card-swt",
     "render_readme": true
 }

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -361,11 +361,11 @@ class OctopusEnergyRatesCard extends HTMLElement {
     }
 }
 
-customElements.define('octopus-energy-rates-card', OctopusEnergyRatesCard);
+customElements.define('octopus-energy-rates-card-swt', OctopusEnergyRatesCard);
 // Configure the preview in the Lovelace card picker
 window.customCards = window.customCards || [];
 window.customCards.push({
-    type: 'octopus-energy-rates-card',
+    type: 'octopus-energy-rates-card-swt',
     name: 'Octopus Energy Rates Card',
     preview: false,
     description: 'This card displays the energy rates for Octopus Energy',

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -65,6 +65,17 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 border-top-right-radius:15px;
                 border-bottom-right-radius:15px;
             }
+            td.rate_emphasis {
+                color:black;
+				font-weight: bold;
+				
+                text-align:center;
+                vertical-align: middle;
+                width:80px;
+
+                border-top-right-radius:15px;
+                border-bottom-right-radius:15px;
+            }
             td.red {
                 border: 2px solid Tomato;
                 background-color: Tomato;
@@ -103,6 +114,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         const currentEntityId = config.currentEntity;
         const futureEntityId = config.futureEntity;
         const pastEntityId = config.pastEntity;
+        const emphasisEntityId = config.emphasisEntity;
         const mediumlimit = config.mediumlimit;
         const highlimit = config.highlimit;
         const unitstr = config.unitstr;
@@ -144,6 +156,14 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 rates_totalnumber ++;
             });
         }
+
+		const emphasisEntitystate = hass.states[emphasisEntityId];
+		var emphasislimit = 5000;
+        if (typeof(emphasisEntitystate) != 'undefined' && emphasisEntitystate != null) {
+		    emphasislimit = parseFloat(emphasisEntitystate.state);
+		} else {
+		}
+
         // Check to see if the 'rates' attribute exists on the chosen entity. If not, either the wrong entity
         // was chosen or there's something wrong with the integration.
         // The rates attribute also appears to be missing after a restart for a while - please see:
@@ -239,8 +259,16 @@ class OctopusEnergyRatesCard extends HTMLElement {
             else if (valueToDisplay <= 0) colour = colours[3];
 
             if(showpast || (date - Date.parse(new Date())>-1800000)) {
-                table = table.concat("<tr class='rate_row'><td class='time time_"+colour+"'>" + date_locale + time_locale + 
-                        "</td><td class='rate "+colour+"'>" + valueToDisplay.toFixed(roundUnits) + unitstr + "</td></tr>");
+                table = table.concat("<tr class='rate_row'>");
+
+				var emphasis = ""
+				if((emphasislimit != 5000) && (key.value_inc_vat < emphasislimit)) {
+					// format of emphass row
+					emphasis = "_emphasis";
+				}
+				table = table.concat("<td class='time time_"+colour+"'>" + date_locale + time_locale + 
+						"</td><td class='rate" + emphasis + " " + colour+"'>" + valueToDisplay.toFixed(roundUnits) + unitstr);
+				table = table.concat("</td></tr>");
 
                 if (x % rows_per_col == 0) {
                     tables = tables.concat(table);


### PR DESCRIPTION
Added a config option called emphasisEntity.
This allows for dynamic emphasis of rates based on the value of this entity.
Rates below this value will be emphasised in bold and black text. 
![Screenshot 2023-11-26 at 12 24 59](https://github.com/lozzd/octopus-energy-rates-card/assets/4236642/1b58a34d-8289-44b1-8fbd-c183f0e22931)
