### PR TITLE
Made Time display optional / fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Here's a breakdown of all the available configuration items:
 | cols          | Y        | 1             | How many columns to break the rates in to, pick the one that fits best with how wide your card is                                                    |
 | showpast      | Y        | false         | Show the rates that have already happened today. Provides a simpler card when there are two days of dates to show                                    |
 | showday       | Y        | false         | Shows the (short) day of the week next to the time for each rate. Helpful if it's not clear which day is which if you have a lot of rates to display |
+| showtime      | Y        | true          | Shows the time for each rate.                                                                                                                        |
 | title         | Y        | "Agile Rates" | The title of the card in the dashboard                                                                                                               |
 | lowlimit      | Y        |  5 (pence)    | If the price is above `lowlimit`, the row is marked dark green. (this option is only applicable for import rates                                     |
 | mediumlimit   | Y        | 20 (pence)    | If the price is above `mediumlimit`, the row is marked yellow                                                                                        |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Here's a breakdown of all the available configuration items:
 | exportrates   | Y        | false         | Reverses the colours for use when showing export rates instead of import                                                                             |
 | hour12        | Y        | true          | Show the times in 12 hour format if `true`, and 24 hour format if `false`                                                                            |
 | cheapest      | Y        | false         | If true show the cheapest rate in light green / light blue                                                                                           |
-| combinerate   | Y        | false         | If true combine rows where the rate is the same price, useful if you have a daily tracker tarrif for instance                                        |
+| combinerate   | Y        | false         | If true combine rows where the rate is the same price, useful if you have a daily tracker tariff for instance                                        |
 | multiplier    | Y        | 100           | multiple rate values for pence (100) or pounds (1)                                                                                                   |
 
 

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -125,6 +125,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         const roundUnits = config.roundUnits;
         const showpast = config.showpast;
         const showday = config.showday;
+        const showtime = config.showtime;
         const hour12 = config.hour12;
         const cheapest = config.cheapest;
         const combinerate = config.combinerate;
@@ -244,7 +245,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
             const lang = navigator.language || navigator.languages[0];
             var options = {hourCycle: 'h23', hour12: hour12, hour: '2-digit', minute:'2-digit'};
             // The time formatted in the user's Locale
-            var time_locale = date.toLocaleTimeString(lang, options);
+            var time_locale = (showtime ? date.toLocaleTimeString(lang, options) + '' : '');
             // If the showday config option is set, include the shortened weekday name in the user's Locale
             var date_locale = (showday ? date.toLocaleDateString(lang, { weekday: 'short' }) + ' ' : '');
 
@@ -327,6 +328,8 @@ class OctopusEnergyRatesCard extends HTMLElement {
             showpast: false,
             // Show the day of the week with the time
             showday: false,
+            // Show the start time of the rates
+            showtime: true,
             // Use 12 or 24 hour time
             hour12: true,
             // Controls the title of the card


### PR DESCRIPTION
Added optional param "showtime", defaults to true so keeps current behaviour and will only effect people who want to set the new option to hide the time.
Also corrected spelling mistake in readme