### PR TITLE
Add rateListLimit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Here's a breakdown of all the available configuration items:
 | cheapest      | Y        | false         | If true show the cheapest rate in light green / light blue                                                                                           |
 | combinerate   | Y        | false         | If true combine rows where the rate is the same price, useful if you have a daily tracker tarrif for instance                                        |
 | multiplier    | Y        | 100           | multiple rate values for pence (100) or pounds (1)                                                                                                   |
-| rowLimit      | Y        | N/A           | Limit number of rates to display, useful if you only want to only show next 4 rates
+| rateListLimit      | Y        | N/A           | Limit number of rates to display, useful if you only want to only show next 4 rates
 
 
 #### A note on colouring

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Here's a breakdown of all the available configuration items:
 | cheapest      | Y        | false         | If true show the cheapest rate in light green / light blue                                                                                           |
 | combinerate   | Y        | false         | If true combine rows where the rate is the same price, useful if you have a daily tracker tarrif for instance                                        |
 | multiplier    | Y        | 100           | multiple rate values for pence (100) or pounds (1)                                                                                                   |
-
+| rowLimit      | Y        | N/A           | Limit number of rates to display, useful if you only want to only show next 4 rates
 
 
 #### A note on colouring

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -231,7 +231,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 previous_rates_day = current_rates_day;
             }
             if(rateListLimit > 0 && rates_list_length == rateListLimit) {
-                return false;
+                throw new Error(); // not ideal, but forEach doesn't check return nor support break
             }
         });
 

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -129,6 +129,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         const cheapest = config.cheapest;
         const combinerate = config.combinerate;
         const multiplier = config.multiplier
+        const rowLimit = config.rowLimit
         var colours = (config.exportrates ? colours_export : colours_import);
         var rates_totalnumber = 0;
         var combinedRates = [];
@@ -228,6 +229,9 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 }
                 previous_rate = ratesToEvaluate;
                 previous_rates_day = current_rates_day;
+            }
+            if(rowLimit > 0 && rates_list_length == rowLimit) {
+                break;
             }
         });
 
@@ -351,7 +355,9 @@ class OctopusEnergyRatesCard extends HTMLElement {
             // Combine equal rates
             combinerate: false,
             // multiple rate values for pence (100) or pounds (1)
-            multiplier: 100
+            multiplier: 100,
+            // Limit display to next X rows
+            rowLimit: 0
         };
 
         const cardConfig = {

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -129,7 +129,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
         const cheapest = config.cheapest;
         const combinerate = config.combinerate;
         const multiplier = config.multiplier
-        const rowLimit = config.rowLimit
+        const rateListLimit = config.rateListLimit
         var colours = (config.exportrates ? colours_export : colours_import);
         var rates_totalnumber = 0;
         var combinedRates = [];
@@ -230,7 +230,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 previous_rate = ratesToEvaluate;
                 previous_rates_day = current_rates_day;
             }
-            if(rowLimit > 0 && rates_list_length == rowLimit) {
+            if(rateListLimit > 0 && rates_list_length == rateListLimit) {
                 break;
             }
         });
@@ -357,7 +357,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
             // multiple rate values for pence (100) or pounds (1)
             multiplier: 100,
             // Limit display to next X rows
-            rowLimit: 0
+            rateListLimit: 0
         };
 
         const cardConfig = {

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -203,7 +203,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
             rates_processingRow ++;
             var ratesToEvaluate = key.value_inc_vat * multiplier;
 
-            if(showpast || (date - Date.parse(new Date())>-1800000)) 
+            if((showpast || (date - Date.parse(new Date())>-1800000)) && (rateListLimit == 0 || rates_list_length < rateListLimit)) 
             {
                 rates_currentNumber++;
                 
@@ -229,9 +229,6 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 }
                 previous_rate = ratesToEvaluate;
                 previous_rates_day = current_rates_day;
-            }
-            if(rateListLimit > 0 && rates_list_length == rateListLimit) {
-                throw new Error(); // not ideal, but forEach doesn't check return nor support break
             }
         });
 

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -231,7 +231,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 previous_rates_day = current_rates_day;
             }
             if(rateListLimit > 0 && rates_list_length == rateListLimit) {
-                break;
+                return false;
             }
         });
 


### PR DESCRIPTION
Rather than displaying all data, allow the option to define optional rateListLimit so you can have a mini-widget that only shows the next 4 values say