### PR TITLE
Add card refresh interval to reduce CPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Here's a breakdown of all the available configuration items:
 | cheapest      | Y        | false         | If true show the cheapest rate in light green / light blue                                                                                           |
 | combinerate   | Y        | false         | If true combine rows where the rate is the same price, useful if you have a daily tracker tarrif for instance                                        |
 | multiplier    | Y        | 100           | multiple rate values for pence (100) or pounds (1)                                                                                                   |
-| rateListLimit      | Y        | N/A           | Limit number of rates to display, useful if you only want to only show next 4 rates
+| rateListLimit      | Y        | N/A           | Limit number of rates to display, useful if you only want to only show next 4 rates                                                             |
+| cardRefreshIntervalSeconds | Y | 60      | How often the card should refresh to avoid using lots of CPU, defaults to once a minute                                                              |
 
 #### A note on colouring
 

--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -124,6 +124,20 @@ class OctopusEnergyRatesCard extends HTMLElement {
             this.appendChild(card);
         }
 
+        // Initialise the lastRefreshTimestamp
+        if (!this.lastRefreshTimestamp) {
+            // Store the timestamp of the last refresh
+            this.lastRefreshTimestamp = 0;
+        }
+
+        // Check if the interval has passed
+        const currentTime = Date.now();
+        const cardRefreshIntervalSecondsInMilliseconds = config.cardRefreshIntervalSeconds * 1000;
+        if (!(currentTime - this.lastRefreshTimestamp >= cardRefreshIntervalSecondsInMilliseconds)) {
+            return
+        }
+        this.lastRefreshTimestamp = currentTime;
+
         const colours_import = ['lightgreen', 'green', 'orange', 'red', 'blue', 'cheapest', 'cheapestblue'];
         const colours_export = ['red', 'green', 'orange', 'green'];
         const currentEntityId = config.currentEntity;
@@ -410,7 +424,9 @@ class OctopusEnergyRatesCard extends HTMLElement {
             // multiple rate values for pence (100) or pounds (1)
             multiplier: 100,
             // Limit display to next X rows
-            rateListLimit: 0
+            rateListLimit: 0,
+            // How often should the card refresh in seconds
+            cardRefreshIntervalSeconds: 60
         };
 
         const cardConfig = {


### PR DESCRIPTION
This PR adds an option for the card to refresh regularly skipping intensive CPU operations and improves the performance.

By default it will refresh once a minute, but it is configurable.
The function gets [called frequent enough](https://github.com/lozzd/octopus-energy-rates-card/issues/59#issuecomment-1915652600) (a few times a second in the tests), so this helps with the CPU usage.

On my macbook it reduced the CPU usage from around 5% to less than 1% according to the task manager (tested on a new dashboard containing only the Agile card).

Fixes: #59 

