### PR TITLE
Multipliers for Dynamic Limits

### DIFF
--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -215,8 +215,9 @@ class OctopusEnergyRatesCard extends HTMLElement {
             const limitExtraData = config.additionalDynamicLimits[entityId] || [];
             const backgroundColour = limitExtraData.backgroundColour || "";
             const timePrefix = limitExtraData.prefix || "";
+            const multiplier = limitExtraData.multiplier || 1;
 
-            const limit = parseFloat(hass.states[entityId].state);
+            const limit = parseFloat(hass.states[entityId].state) * parseFloat(multiplier);
             if (!isNaN(limit)) {
                 additionalDynamicLimits.push({
                     limit: limit,


### PR DESCRIPTION
DynamicLimits can now apply a multiplier in the case where the  number_input entity is in pence while the tariff is in pounds.