### PR TITLE
Dedicated column for target time prefix

### DIFF
--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -38,7 +38,6 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 display: block;
                 border-top: calc(var(--paper-font-body1_-_line-height)*0.65) solid transparent;
                 border-bottom: calc(var(--paper-font-body1_-_line-height)*0.65) solid transparent;
-
                 border-right: 10px solid;
             }
             thead th {
@@ -56,6 +55,10 @@ class OctopusEnergyRatesCard extends HTMLElement {
             }
             td.time {
                 text-align:center;
+                vertical-align:middle;
+            }
+            td.target {
+                text-align: right;
                 vertical-align: middle;
             }
             td.time_red{
@@ -84,7 +87,6 @@ class OctopusEnergyRatesCard extends HTMLElement {
                 text-align:center;
                 vertical-align: middle;
                 width:80px;
-
                 border-top-right-radius:15px;
                 border-bottom-right-radius:15px;
             }
@@ -361,7 +363,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
             });
 
             // Add the extra space at the end of the prefix if it's not empty
-            targetTimePrefix = targetTimePrefix ? targetTimePrefix + " " : targetTimePrefix;
+            // targetTimePrefix = targetTimePrefix ? targetTimePrefix + " " : targetTimePrefix;
             var isCurrentTime = false;
             if ((date - Date.parse(new Date()) > -1800000) && (date < new Date())) {
                 if (showpast) {
@@ -382,7 +384,7 @@ class OctopusEnergyRatesCard extends HTMLElement {
             else if (valueToDisplay <= 0) colour = colours[4]; // below 0 - blue (import/export)
 
             if (showpast || (date - Date.parse(new Date()) > -1800000)) {
-                table = table.concat("<tr class='rate_row'><td class='time " + boldStyle + " " + "time_" + colour + targetTimeBackgroundColor + "'>" + targetTimePrefix + date_locale + time_locale +
+                table = table.concat("<tr class='rate_row'><td class='target " + "time_" + colour + targetTimeBackgroundColor + "'>" + targetTimePrefix + "<td class='time " + boldStyle + " " + "time_" + colour + targetTimeBackgroundColor + "'>" + date_locale + time_locale +
                     "</td><td class='rate " + colour + "'>" + valueToDisplay.toFixed(roundUnits) + unitstr + "</td></tr>");
 
                 if (x % rows_per_col == 0) {


### PR DESCRIPTION
Add a new column to the left of the timestamp to hold the prefix for any target time entries. Ensures that the times still remain aligned when there's a target time.