### PR TITLE
Time Zones Fix

### DIFF
--- a/octopus-energy-rates-card.js
+++ b/octopus-energy-rates-card.js
@@ -194,7 +194,24 @@ class OctopusEnergyRatesCard extends HTMLElement {
         const rateListLimit = config.rateListLimit
         const navigatorLanguage = (typeof navigator !== 'undefined') ? (navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language) : 'en-US';
         const language = hass.locale?.language || hass.language || navigatorLanguage || 'en-US';
-        const timeZone = hass.locale?.time_zone || hass.config?.time_zone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const isValidTimeZone = (tz) => {
+            if (!tz) {
+                return false;
+            }
+            try {
+                new Intl.DateTimeFormat(undefined, { timeZone: tz });
+                return true;
+            } catch (_error) {
+                return false;
+            }
+        };
+        const candidateTimeZones = [
+            hass.locale?.time_zone,
+            hass.config?.time_zone,
+            Intl.DateTimeFormat().resolvedOptions().timeZone,
+            'UTC',
+        ];
+        const timeZone = candidateTimeZones.find((tz) => isValidTimeZone(tz));
         const dayFormatter = new Intl.DateTimeFormat(language, { weekday: 'short', timeZone });
         const timeFormatter = new Intl.DateTimeFormat(language, {
             hour: '2-digit',


### PR DESCRIPTION
Hi, 

This has been created to fix https://github.com/lozzd/octopus-energy-rates-card/issues/75

Created a fork and tested out locally. I am currently at my local timezone + 5.5 hours, and it works great.

Suggest testing on your own system to make sure it doesn't do other weird stuff. But for me, it fixed the major TZ issue.

Here is my system before adding the timezone information ... 
<img width="563" height="710" alt="Screenshot 2026-01-12 at 06 24 50" src="https://github.com/user-attachments/assets/3d2942c6-7fe5-482c-ae88-33a10e13f170" />

Here it is after adding in the time zone info ...
<img width="435" height="639" alt="Screenshot 2026-01-12 at 08 24 10" src="https://github.com/user-attachments/assets/3ad986b9-bbc5-4f94-9430-2216a76ce5e7" />

Regards

Nick